### PR TITLE
Fix misspelled infrastructure team in auto-assign workflow

### DIFF
--- a/.github/workflows/issue_assignment.yml
+++ b/.github/workflows/issue_assignment.yml
@@ -13,5 +13,5 @@ jobs:
       - name: "Auto-assign issue"
         uses: pozil/auto-assign-issue@v2
         with:
-          teams: instrastructure
+          teams: infrastructure
           repo-token: ${{ secrets.infra_automation }}


### PR DESCRIPTION
## Description
This PR fixes a typo in the issue auto-assignment workflow where the team name was misspelled as instrastructure
After Fix - infrastructure

closes #75 